### PR TITLE
Add: Regex to exclude certain commits from the changelog

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ inputs:
     description: The Github issue number
     default: ${{ github.event.number }}
     required: false
+  commit_regex:
+    description: A regular expression used to filter out commits.
+    required: false
 outputs:
   changelog:
     description: "The generated changelog"

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,8 @@ async function main(): Promise<void> {
     case "changelog":
       await generateChangelog(
         github.rest,
-        core.getInput("workflow_id", { required: true })
+        core.getInput("workflow_id", { required: true }),
+        core.getInput("commit_regex", { required: false })
       );
       break;
     default:


### PR DESCRIPTION
As many people sometimes have commits that do not affect the users, a regex to filter the output might be helpful. For example `(Codechange|Refactor)(.*)` would be a helpful regex in my repositories, as those commits should really not be noted inside of the changelog. (I know, this might not be specific to any fabric project - but it still could be useful for other developers.)